### PR TITLE
Add basic ZFS filesystem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ It **should** work for other cloud providers and environments, such as rasperrry
 
 ## ZFS support and PoC partitioner
 
-* include zfs kernel and runtime
 * implement partitioner (single disk)
 * implement example with encrypted boot
 * implement partitioner and test for mirrored layouts

--- a/configuration.nix
+++ b/configuration.nix
@@ -49,7 +49,7 @@
       # E.g. ext4 for hetzner.cloud, presumably to allow our kexec'ed
       # kernel to load its initrd.
       supportedFilesystems = [
-        "vfat" "ext4"
+        "vfat" "ext4" "zfs"
       ];
       # We aim to provide a default set of kernel modules which should
       # support functionality for nixos installers on generic cloud
@@ -74,6 +74,12 @@
         "sr_mod"  # SCSI cdrom support
       ];
    };
+
+   # Enable ZFS support using the unstable package. There is rarely a
+   # version difference between stable & unstable, but maybe unstable pulls
+   # in some hypothetical future fix earlier than stable.
+   boot.kernelPackages = pkgs.zfsUnstable.latestCompatibleLinuxPackages;
+   boot.zfs.enableUnstable = true;
 
    # Nix-dabei isn't intended to keep state, but NixOS wants
    # it defined and it does not hurt. You are still able to


### PR DESCRIPTION
Tested to work w/ zpool & datasets created on a Hetzner rescue system, afterwards imported to kexec'd `nix-dabei`

This change increases the `initrd` size by ~70MB

Possible improvements to reduce `initrd` size
- Remove dependencies on `python` `samba` `systemd` (replace w/ `systemd-minimal`