### PR TITLE
Fix umount behaviour

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -247,8 +247,8 @@ let cfg = config.nix-dabei; in
             unitConfig.DefaultDependencies = false;
             serviceConfig.Type = "oneshot";
             script = ''
-                umount /mnt/boot
-                zfs umount -a
+                set -o errexit
+                umount --recursive /mnt
                 zpool export rpool
                 reboot
             '';


### PR DESCRIPTION
This fixes multiple issues
- Script not exiting if any of the commands fail
- 'zfs umount' does not unmount recursively 
- '/mnt' not getting unmounted. The zfs dataset is mounted as a legacy mount, 'zfs umount' does not unmount those
- umount of '/mnt' failing if additional mountpoints (beside 'boot') exist or non-ZFS filesystem mounted into '/mnt'