### PR TITLE
Improve umounting process

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -249,7 +249,7 @@ let cfg = config.nix-dabei; in
             script = ''
                 set -o errexit
                 umount --verbose --recursive /mnt
-                zpool export -af
+                zpool export -a
                 echo -e "Currently imported zpool(s)"; zpool list
                 reboot
             '';

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -248,8 +248,9 @@ let cfg = config.nix-dabei; in
             serviceConfig.Type = "oneshot";
             script = ''
                 set -o errexit
-                umount --recursive /mnt
-                zpool export rpool
+                umount --verbose --recursive /mnt
+                zpool export -af
+                echo -e "Currently imported zpool(s)"; zpool list
                 reboot
             '';
           };


### PR DESCRIPTION
- Export all created pools - always
- Add logging for unmounting filesystems
- Add logging output after 'zpool export' since it does not have a verbose flag