### PR TITLE
Don't trigger automatic restart without installer

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -245,6 +245,7 @@ let cfg = config.nix-dabei; in
             requiredBy = [ "initrd.target" ];
             before = [ "initrd.target" ];
             unitConfig.DefaultDependencies = false;
+            unitConfig.ConditionPathExists = "/run/flake_url";
             serviceConfig.Type = "oneshot";
             script = ''
                 set -o errexit


### PR DESCRIPTION
The automatic restart service was always triggered, even if no installer was started via the kexec 'flake_url' parameter.

Before initiating the reboot all folders under '/mnt' get unmounted. This command failed since no installer was started and hence aborted further execution of the systemd unit, blocking an automatic restart.
```
# systemctl --no-pager --full status reboot-after-install
× reboot-after-install.service
     Loaded: loaded (/etc/systemd/system/reboot-after-install.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Mon 2022-11-14 23:39:01 UTC; 7min ago
    Process: 192 ExecStart=/nix/store/hkg95r06qfbh9pr84z9dv57zhw5nyz51-unit-script-reboot-after-install-start/bin/reboot-after-install-start (code=exited, status=1/FAILURE)
   Main PID: 192 (code=exited, status=1/FAILURE)
        CPU: 6ms

Nov 14 23:39:01 nix-dabei systemd[1]: Starting reboot-after-install.service...
Nov 14 23:39:01 nix-dabei reboot-after-install-start[193]: umount: /mnt: not mounted
Nov 14 23:39:01 nix-dabei systemd[1]: reboot-after-install.service: Main process exited, code=exited, status=1/FAILURE
Nov 14 23:39:01 nix-dabei systemd[1]: reboot-after-install.service: Failed with result 'exit-code'.
Nov 14 23:39:01 nix-dabei systemd[1]: Failed to start reboot-after-install.service.
```

This commit adds the same conditional to the reboot service that guards the installer service.