### PR TITLE
Configure systemd/ journald pager

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -96,6 +96,10 @@ let cfg = config.nix-dabei; in
             root:x:0:
             nogroup:x:65534:
         '';
+        "profile".text = ''
+            export SYSTEMD_COLORS=false
+            export SYSTEMD_PAGER="cat"
+        '';
       };
 
       boot.initrd.systemd = {


### PR DESCRIPTION
As per `man 1 journald` [1] environment variables can be used to control the output behaviour of systemd tools.

By setting the pager to `cat` (less is not available in the kexec image) warnings about the terminal not being fully functional are avoided. Disabling color makes certain low-contrast (foreground vs background) colors more readable.

[1] https://www.man7.org/linux/man-pages/man1/journalctl.1.html