### PR TITLE
Force TERM environment variable for shells

### DIFF
--- a/modules/core.nix
+++ b/modules/core.nix
@@ -124,6 +124,9 @@ let cfg = config.nix-dabei; in
               root:x:0:
               nogroup:x:65534:
             '';
+            "profile".text = ''
+              export TERM=vt102
+            '';
           };
 
           systemd = {


### PR DESCRIPTION
Commit 86abfdd980ca7281fedc3d651381f22d44dd1f05 included a terminfo definition for `vt102` in order to fix #20, but only covered 1 out of 2 steps for the solution: 1) Include a valid terminfo
2) Force terminal type for all shells
This commit adds step number 2), which is necessary because according to `man 5 ssh_config`

> Note that the TERM environment variable is always sent whenever a pseudo-terminal is requested as it is required by the protocol.

Which yields the observable behaviour that the `TERM` variable of a SSH connection has the value of the client shell it was started from, unless explicitly set configured on the remote system.

Correct behaviour can be verified using `systemctl -a` over a SSH connection. If the `TERM` variable is set to a value that does not correspond to an existing terminfo file, the following warning is shown

```sh
-sh-5.1# systemctl -a      
WARNING: terminal is not fully functional
Press RETURN to continue 
```