### PR TITLE
Remove IP DHCP config from kernel parameters

### DIFF
--- a/modules/core.nix
+++ b/modules/core.nix
@@ -85,7 +85,6 @@ let cfg = config.nix-dabei; in
       boot = {
         loader.grub.enable = false;
         kernelParams = [
-          "ip=dhcp"
           "systemd.show_status=true"
           "systemd.log_level=info"
           "systemd.log_target=console"


### PR DESCRIPTION
'systemd-network-generator' fails with error: 

```sh
Failed to create unit file /run/systemd/network/91-default.network, as it already exists. Duplicate entry in kernel command line?
```
when trying to re-configure the network interfaces for DHCP as instructed by the kernel parameters.

systemds default configuration for network interfaces is DHCP, removing the kernel parameter fixes 'systemd-network-generator' errors.