### PR TITLE
workflows: Automate GH Actions updates w/ dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+---
+version: 2
+updates:
+  # Update dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should resolve the Annotations/ warnings about outdated Node.js version in the build pipeline.

See https://github.com/dep-sys/nix-dabei/actions/runs/3591245127 for example