### PR TITLE
workflows: Disable cachix for forked builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     - name: Install nix
       uses: cachix/install-nix-action@v17
     - name: Setup Cache
+      if: ${{ github.repository == 'dep-sys/nix-dabei' }}
       uses: cachix/cachix-action@v10
       with:
         name: nix-dabei


### PR DESCRIPTION
If one forks `nix-dabei` and re-enables GitHub actions but does not have a cachix account every build verification fails.

This PR makes the use of `cachix` conditional for the upstream repo only.