### PR TITLE
Remove jq in initrd

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -p 2222 -i fixture
 
 ``` sh
 # build a kexec bundle
-kexec="$(nix build .#kexec --json| jq -r '.[].outputs.out')"
+kexec="$(nix build .#kexec --no-link --print-out-paths)"
 
 # copy it to your $TARGET_SERVER
 rsync \

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -22,10 +22,10 @@ lib.mkIf config.nix-dabei.auto-install.enable {
 
           udevadm trigger --subsystem-match=block; udevadm settle
           echo "Formatting disk..."
-          formatScript="$(nix build --no-link --json "''${flake_url}.config.system.build.formatScript" | jq -r '.[].outputs.out')"
+          formatScript="$(nix build --no-link --print-out-paths "''${flake_url}.config.system.build.formatScript")"
           $formatScript
           echo "Mounting disk..."
-          mountScript="$(nix build --no-link --json "''${flake_url}.config.system.build.mountScript" | jq -r '.[].outputs.out')"
+          mountScript="$(nix build --no-link --print-out-paths "''${flake_url}.config.system.build.mountScript")"
           $mountScript
 
           echo "Installing $flake_url"

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -58,7 +58,7 @@ let cfg = config.nix-dabei; in
       # Nix-dabei isn't intended to keep state, but NixOS wants
       # it defined and it does not hurt. You are still able to
       # install any realease with the images built.
-      system.stateVersion = "22.11";
+      system.stateVersion = lib.trivial.release;
 
       # toplevel does not build without a root fs but is useful for debugging
       # and it does not seem to hurt

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -142,7 +142,6 @@ let cfg = config.nix-dabei; in
 
               # partitioning
               parted = "${pkgs.parted}/bin/parted";
-              jq = "${pkgs.jq}/bin/jq";
 
               get-kernel-param = pkgs.writeScript "get-kernel-param" ''
                 for o in $(< /proc/cmdline); do


### PR DESCRIPTION
- Use `lib.trivial.release` [Reference](https://github.com/NixOS/nixpkgs/blob/a0ba4fa973847f2c8a5632af834fcce66bf55cb0/nixos/modules/installer/cd-dvd/installation-cd-base.nix#L49 )
- Remove jq in initrd