### PR TITLE
support install UEFI systemd-boot system

### DIFF
--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -28,6 +28,9 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           mountScript="$(nix build --no-link --json "''${flake_url}.config.system.build.mountScript" | jq -r '.[].outputs.out')"
           $mountScript
 
+          # support UEFI systemd-boot
+          mount -t efivarfs efivarfs /sys/firmware/efi/efivars || true
+
           echo "Installing $flake_url"
           mkdir -p /mnt/{etc,tmp}
           touch /mnt/etc/NIXOS

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -81,7 +81,7 @@ let cfg = config.nix-dabei; in
         ];
 
         initrd = {
-          kernelModules = [ "virtio_pci" "virtio_scsi" "ata_piix" "sd_mod" "sr_mod" "ahci" "nvme" ];
+          kernelModules = [ "efivarfs" "virtio_pci" "virtio_scsi" "ata_piix" "sd_mod" "sr_mod" "ahci" "nvme" ];
           network = {
             enable = true;
           };


### PR DESCRIPTION
Oracle Cloud and Azure use UEFI Firmware

`boot.loader.efi.canTouchEfiVariables` is `true` for UEFI systemd-boot.
During `NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root /mnt -- /run/current-system/bin/switch-to-configuration boot`, `systemd/bin/bootctl install` will modify `/sys/firmware/efi/efivars`


https://github.com/NixOS/nixpkgs/issues/38477#issuecomment-379417134

https://github.com/NixOS/nixpkgs/blob/04a75b2eecc0acf6239acf9dd04485ff8d14f425/nixos/modules/virtualisation/qemu-vm.nix#L265

https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface#Mount_efivarfs


fixed #35 