### PR TITLE
Add NTP sync to kexec startup process - take #2

### DIFF
--- a/modules/core.nix
+++ b/modules/core.nix
@@ -28,6 +28,30 @@ let cfg = config.nix-dabei; in
       type = types.bool;
       default = true;
     };
+    ntpSync = {
+      enable = mkOption {
+        description = "Enable NTP sync during kexec image startup.";
+        type = types.bool;
+        default = true;
+      };
+      updateHwClock = mkOption {
+        description = ''
+          NTPdate only synchronizes the software clock. If 'updateHwClock' is
+          true, the synchronized time will also be written to the hardware clock.
+          Disabled per default as it might produce unwanted side-effects on
+          virtualized hardware clocks in VMs.
+          Enabling this option makes most sense for physical servers with real
+          hardware clocks.
+        '';
+          type = types.bool;
+          default = false;
+      };
+      servers = mkOption {
+        description = "NTP server to use for timesync during startup";
+        type = types.listOf types.str;
+        default = config.networking.timeServers;
+      };
+    };
   };
 
   config = lib.mkMerge [
@@ -140,6 +164,10 @@ let cfg = config.nix-dabei; in
               ssh-keygen = "${config.programs.ssh.package}/bin/ssh-keygen";
               setsid = "${pkgs.util-linux}/bin/setsid";
 
+              # NTP time synchronization
+              hwclock = "${pkgs.util-linux}/bin/hwclock";
+              ntpdate = "${pkgs.ntp}/bin/ntpdate";
+
               # partitioning
               parted = "${pkgs.parted}/bin/parted";
               jq = "${pkgs.jq}/bin/jq";
@@ -246,6 +274,30 @@ let cfg = config.nix-dabei; in
         initrd-switch-root.enable = false;
         initrd-cleanup.enable = false;
         initrd-parse-etc.enable = false;
+      };
+    })
+
+
+    # Synchronize time using NTP to prevent clock skew that could interfere
+    # with date & time sensitive operations like certificate verification.
+    (lib.mkIf cfg.ntpSync.enable {
+      boot.initrd.systemd.services.ntpdate-timesync = let
+       ntpServersAsString = lib.concatStringsSep " " cfg.ntpSync.servers;
+     in {
+        requires = [ "initrd-fs.target" "network-online.target"];
+        requiredBy = [ "auto-installer.service" ];
+        before = [ "auto-installer.service" ];
+        after = [ "initrd-fs.target" "network-online.target"];
+        unitConfig.DefaultDependencies = false;
+        serviceConfig.Type = "oneshot";
+        script = ''
+            ntpdate -b ${ntpServersAsString}
+            if [[ "${lib.boolToString cfg.ntpSync.updateHwClock}" == "true" ]]; then
+dantefromhell marked this conversation as resolved.
+Show resolved
+              hwclock --systohc
+            fi
+        '';
       };
     })
   ];

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -292,11 +292,7 @@ let cfg = config.nix-dabei; in
         serviceConfig.Type = "oneshot";
         script = ''
             ntpdate -b ${ntpServersAsString}
-            if [[ "${lib.boolToString cfg.ntpSync.updateHwClock}" == "true" ]]; then
-dantefromhell marked this conversation as resolved.
-Show resolved
-              hwclock --systohc
-            fi
+            ${lib.optionalString cfg.ntpSync.updateHwClock "hwclock --systohc"}
         '';
       };
     })


### PR DESCRIPTION
'ntpdate' synchronizes time to a given server and exist afterwards - it does not serve as an NTP daemon. Flag '-b' ensures 'settimeofday()' is used to step the clock as required. When 'ntpdate' exits a correct time can be assumed.

This is a re-start of #19 