### PR TITLE
auto partitioning via `diskoConfiguration` & mirrored zfs

### DIFF
--- a/create-hcloud-machine.sh
+++ b/create-hcloud-machine.sh
@@ -30,7 +30,7 @@ rsync \
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
 flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
-ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url disks=zfs-single:/dev/sda"
+ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot flake_url=$flake_url disks=zfs-single:/dev/sda ssh_authorized_key=$ssh_authorized_key"
 sleep 3
 wait_for_ssh "$TARGET_SERVER"
 

--- a/create-hcloud-machine.sh
+++ b/create-hcloud-machine.sh
@@ -30,7 +30,7 @@ rsync \
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
 flake_url="github:dep-sys/nix-dabei?dir=demo#nixosConfigurations.web-01"
-ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url"
+ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url disks=/dev/sda"
 wait_for_ssh "$TARGET_SERVER"
 
 ssh $SSH_ARGS "root@$TARGET_SERVER" journalctl -u auto-installer -f

--- a/create-hcloud-machine.sh
+++ b/create-hcloud-machine.sh
@@ -29,7 +29,7 @@ rsync \
 
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
-flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
+flake_url="github:dep-sys/nix-dabei/?dir=demo#nixosConfigurations.web-01"
 ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot flake_url=$flake_url disks=zfs-single:/dev/sda ssh_authorized_key=$ssh_authorized_key"
 sleep 3
 wait_for_ssh "$TARGET_SERVER"

--- a/create-hcloud-machine.sh
+++ b/create-hcloud-machine.sh
@@ -29,7 +29,7 @@ rsync \
 
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
-flake_url="github:dep-sys/nix-dabei?dir=demo#nixosConfigurations.web-01"
+flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
 ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url disks=/dev/sda"
 wait_for_ssh "$TARGET_SERVER"
 

--- a/demo/boot.nix
+++ b/demo/boot.nix
@@ -30,5 +30,10 @@
         fsType = "zfs";
         neededForBoot = true;
       };
+    "/home" =
+      {
+        device = "rpool/safe/home";
+        fsType = "zfs";
+      };
   };
 }

--- a/demo/boot.nix
+++ b/demo/boot.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+{
+  boot.loader.grub = {
+    enable = true;
+    # We use "nodev" here to avoid having to declare the disk device (e.g. /dev/sda) in
+    # this config, so we'll only need to know about it during install-time.
+    device = "nodev";
+  };
+  # boot.loader.grub.device = "nodev" excludes grub from the system,
+  # but we need it inside the systems close and optimally inside PATH
+  # do be able to call it during auto-install.
+  environment.systemPackages = [ pkgs.grub2 ];
+
+  fileSystems = {
+    "/boot" =
+      {
+        device = "/dev/disk/by-partlabel/ESP";
+        fsType = "vfat";
+        neededForBoot = true;
+      };
+    "/" =
+      {
+        device = "rpool/local/root";
+        fsType = "zfs";
+        neededForBoot = true;
+      };
+    "/nix" =
+      {
+        device = "rpool/local/nix";
+        fsType = "zfs";
+        neededForBoot = true;
+      };
+  };
+}

--- a/demo/flake.lock
+++ b/demo/flake.lock
@@ -23,28 +23,6 @@
         "type": "github"
       }
     },
-    "disko": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-dabei",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1670157103,
-        "narHash": "sha256-EDvoYUwi7RB/oSOtbk7ykRQXQ0KI5A+UPI8D/TanYXY=",
-        "owner": "nix-community",
-        "repo": "disko",
-        "rev": "e0ce5fb75f1197cf57b0a5c46434d69c14efc842",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "master",
-        "repo": "disko",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -73,25 +51,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nix-dabei": {
-      "inputs": {
-        "disko": "disko",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1670497549,
-        "narHash": "sha256-am0scHGm8nJzrY5JYGrtGtiV0WLyEOGudPan6Zgx62M=",
-        "owner": "dep-sys",
-        "repo": "nix-dabei",
-        "rev": "eff63f66502f7da3253261e9ee65ba3e4314fa33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dep-sys",
-        "repo": "nix-dabei",
         "type": "github"
       }
     },
@@ -139,27 +98,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1670263530,
-        "narHash": "sha256-e02SQGQcKxgyJlV0HWE9MBWIyjJX1spxcwYb/2RumZ4=",
-        "owner": "phaer",
-        "repo": "nixpkgs",
-        "rev": "08dd346b3f7a3975a49fde10cb57fba523d856e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phaer",
-        "ref": "nix-dabei",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1670242877,
-        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
+        "lastModified": 1670507980,
+        "narHash": "sha256-riNZa0xzM1it3pzxciwALeMs+0CsBMWIW2FqulzK8vM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "2787fc7d1e51404678614bf0fe92fc296746eec0",
         "type": "github"
       },
       "original": {
@@ -172,8 +115,7 @@
     "root": {
       "inputs": {
         "colmena": "colmena",
-        "nix-dabei": "nix-dabei",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "stable": {

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -30,6 +30,7 @@
       web-01 = { name, nodes, pkgs, lib, config, modulesPath, ... }: {
         imports = [
           "${modulesPath}/profiles/qemu-guest.nix"
+          ./boot.nix
         ];
 
         config = {
@@ -38,38 +39,6 @@
             targetPort = 22;
             targetUser = "root";
             buildOnTarget = true;
-          };
-
-          boot.loader.grub = {
-            enable = true;
-            # We use "nodev" here to avoid having to declare the disk device (e.g. /dev/sda) in
-            # this config, so we'll only need to know about it during install-time.
-            device = "nodev";
-          };
-          # boot.loader.grub.device = "nodev" excludes grub from the system,
-          # but we need it inside the systems close and optimally inside PATH
-          # do be able to call it during auto-install.
-          environment.systemPackages = [ pkgs.grub2 ];
-
-          fileSystems = {
-            "/boot" =
-              {
-                device = "/dev/disk/by-partlabel/ESP";
-                fsType = "vfat";
-                neededForBoot = true;
-              };
-            "/" =
-              {
-                device = "rpool/local/root";
-                fsType = "zfs";
-                neededForBoot = true;
-              };
-            "/nix" =
-              {
-                device = "rpool/local/nix";
-                fsType = "zfs";
-                neededForBoot = true;
-              };
           };
 
           services.openssh = {

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -17,7 +17,6 @@
     sshKeys = [
       "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLopgIL2JS/XtosC8K+qQ1ZwkOe1gFi8w2i1cd13UehWwkxeguU6r26VpcGn8gfh6lVbxf22Z9T2Le8loYAhxANaPghvAOqYQH/PJPRztdimhkj2h7SNjP1/cuwlQYuxr/zEy43j0kK0flieKWirzQwH4kNXWrscHgerHOMVuQtTJ4Ryq4GIIxSg17VVTA89tcywGCL+3Nk4URe5x92fb8T2ZEk8T9p1eSUL+E72m7W7vjExpx1PLHgfSUYIkSGBr8bSWf3O1PW6EuOgwBGidOME4Y7xNgWxSB/vgyHx3/3q5ThH0b8Gb3qsWdN22ZILRAeui2VhtdUZeuf2JYYh8L"
     ];
-    bootDisk = "/dev/sda";
   in {
     apps.${system} = {
       colmena = colmena.apps.${system}.default;
@@ -43,10 +42,8 @@
             buildOnTarget = true;
           };
 
-          disko.devices = nix-dabei.diskoConfigurations.zfs-simple { diskDevice = bootDisk; };
           boot.loader.grub = {
             enable = true;
-            devices = [ bootDisk ];
           };
 
           services.openssh = {

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -42,8 +42,14 @@
 
           boot.loader.grub = {
             enable = true;
+            # We use "nodev" here to avoid having to declare the disk device (e.g. /dev/sda) in
+            # this config, so we'll only need to know about it during install-time.
             device = "nodev";
           };
+          # boot.loader.grub.device = "nodev" excludes grub from the system,
+          # but we need it inside the systems close and optimally inside PATH
+          # do be able to call it during auto-install.
+          environment.systemPackages = [ pkgs.grub2 ];
 
           fileSystems = {
             "/boot" =

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -44,8 +44,6 @@
             enable = true;
             device = "nodev";
           };
-          # grub.devices = "nodev" removes grub from the derivation, but we need it.
-          system.build.grub = lib.mkForce pkgs.grub2;
 
           fileSystems = {
             "/boot" =

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nix-dabei.url = "github:dep-sys/nix-dabei";
     colmena.url = "github:zhaofengli/colmena/main";
   };
 
@@ -11,7 +10,7 @@
   nixConfig.extra-substituters = [ "https://colmena.cachix.org" ];
   nixConfig.extra-trusted-public-keys = [ "colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg=" ];
 
-  outputs = { self, nixpkgs, nix-dabei, colmena, ... }: let
+  outputs = { self, nixpkgs, colmena, ... }: let
     system = "x86_64-linux";
     pkgs = import nixpkgs { inherit system; };
     sshKeys = [

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -44,6 +44,8 @@
             enable = true;
             device = "nodev";
           };
+          # grub.devices = "nodev" removes grub from the derivation, but we need it.
+          system.build.grub = lib.mkForce pkgs.grub2;
 
           fileSystems = {
             "/boot" =

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -43,6 +43,28 @@
 
           boot.loader.grub = {
             enable = true;
+            device = "nodev";
+          };
+
+          fileSystems = {
+            "/boot" =
+              {
+                device = "/dev/disk/by-partlabel/ESP";
+                fsType = "vfat";
+                neededForBoot = true;
+              };
+            "/" =
+              {
+                device = "rpool/local/root";
+                fsType = "zfs";
+                neededForBoot = true;
+              };
+            "/nix" =
+              {
+                device = "rpool/local/nix";
+                fsType = "zfs";
+                neededForBoot = true;
+              };
           };
 
           services.openssh = {

--- a/demo/flake.nix
+++ b/demo/flake.nix
@@ -31,7 +31,6 @@
       web-01 = { name, nodes, pkgs, lib, config, modulesPath, ... }: {
         imports = [
           "${modulesPath}/profiles/qemu-guest.nix"
-          nix-dabei.inputs.disko.nixosModules.disko
         ];
 
         config = {

--- a/deploy-hetzner-dedicated.sh
+++ b/deploy-hetzner-dedicated.sh
@@ -1,6 +1,10 @@
 set -euxo pipefail
 
-TARGET_SERVER="$1"
+export TARGET_SERVER="${1:-$TARGET_SERVER}"
+export TARGET_IP="${2:-$TARGET_IP}"
+export TARGET_GATEWAY="${3:-$TARGET_GATEWAY}"
+export TARGET_NETMASK="${4:-$TARGET_NETMASK}"
+export TARGET_DEVICE="${5:-$TARGET_DEVICE}"
 
 SSH_ARGS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 wait_for_ssh() {
@@ -22,7 +26,10 @@ rsync \
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
 flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
-ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url disks=zfs-mirror:/dev/sda,/dev/sdb"
+
+# ip=<client-ip>:<nfs-server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
+static_ip="${TARGET_IP}::${TARGET_GATEWAY}:${TARGET_NETMASK}:${TARGET_SERVER}:${TARGET_DEVICE}"
+ssh $SSH_ARGS "root@$TARGET_SERVER" "./kexec-boot ip=$static_ip flake_url=$flake_url disks=zfs-mirror:/dev/sda,/dev/sdb ssh_authorized_key=$ssh_authorized_key"
 wait_for_ssh "$TARGET_SERVER"
 
 ssh $SSH_ARGS "root@$TARGET_SERVER" journalctl -u auto-installer -f

--- a/deploy-hetzner-dedicated.sh
+++ b/deploy-hetzner-dedicated.sh
@@ -25,7 +25,7 @@ rsync \
 
 
 ssh_authorized_key="$(base64 -w0 < ~/.ssh/yubikey.pub)"
-flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
+flake_url="github:dep-sys/nix-dabei/?dir=demo#nixosConfigurations.web-01"
 
 # ip=<client-ip>:<nfs-server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
 static_ip="${TARGET_IP}::${TARGET_GATEWAY}:${TARGET_NETMASK}:${TARGET_SERVER}:${TARGET_DEVICE}"

--- a/disk-layouts/zfs-mirror.nix
+++ b/disk-layouts/zfs-mirror.nix
@@ -9,7 +9,7 @@
           {
             name = "boot";
             type = "partition";
-            start = "0";
+            start = "0%";
             end = "1M";
             part-type = "primary";
             flags = ["bios_grub"];

--- a/disk-layouts/zfs-mirror.nix
+++ b/disk-layouts/zfs-mirror.nix
@@ -1,9 +1,5 @@
-{ disks, ... }:
-let
-  disk = builtins.head disks;
-in {
-  disk = {
-    ${disk} = {
+{ disks, lib, ... }: {
+  disk = lib.genAttrs disks (disk: {
       device = disk;
       type = "disk";
       content = {
@@ -43,12 +39,11 @@ in {
           }
         ];
       };
-    };
-  };
+  });
   zpool = {
     rpool = {
       type = "zpool";
-      mode = "";
+      mode = "mirror";
       rootFsOptions = {
         compression = "zstd";
         acltype = "posixacl";

--- a/disk-layouts/zfs-simple.nix
+++ b/disk-layouts/zfs-simple.nix
@@ -1,7 +1,7 @@
-{ diskDevice, ... }: {
+{ disk, ... }: {
   disk = {
-    ${diskDevice} = {
-      device = diskDevice;
+    ${disk} = {
+      device = disk;
       type = "disk";
       content = {
         type = "table";

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1670157103,
-        "narHash": "sha256-EDvoYUwi7RB/oSOtbk7ykRQXQ0KI5A+UPI8D/TanYXY=",
-        "owner": "nix-community",
+        "lastModified": 1670283933,
+        "narHash": "sha256-ZHLBzJr9ECprzEKaSvAvTGdsb/O/GN340MTafeyFOGM=",
+        "owner": "phaer",
         "repo": "disko",
-        "rev": "e0ce5fb75f1197cf57b0a5c46434d69c14efc842",
+        "rev": "ee67d1695fe80c304b2741609fda2f086b9ff5c5",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "ref": "master",
+        "owner": "phaer",
+        "ref": "allow-variables",
         "repo": "disko",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
 
       diskoConfigurations = {
         zfs-simple = import ./disk-layouts/zfs-simple.nix;
+        zfs-mirror = import ./disk-layouts/zfs-mirror.nix;
       };
 
       nixosModules = {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,8 @@
   # https://github.com/NixOS/nixpkgs/pull/169116/files
   # (rebased on master from time to time)
   inputs.nixpkgs.url = "github:phaer/nixpkgs/nix-dabei";
-  inputs.disko.url = "github:nix-community/disko/master";
+  # https://github.com/nix-community/disko/pull/72
+  inputs.disko.url = "github:phaer/disko/allow-variables";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, disko }:

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -101,7 +101,8 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           echo "Installing grub..."
           # TODO read $disks from files or so, in order to be able to split the installer into phases again.
           # ( can't depend on "global" shell vars )
-          # TODOL: uefi support: don't install grub at all, depend well-known path?
+          # TODO: test & fix uefi support: don't install grub at all, depend well-known path?
+          # TODO mirror: ensure that resulting system boots from any disk and updates both /boot partitions
           for disk in ''${disks[@]}; do
               nixos-enter --root /mnt -- /run/current-system/sw/sbin/grub-install $disk
           done

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -1,17 +1,25 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, disko, diskoConfigurations, ... }:
 lib.mkIf config.nix-dabei.auto-install.enable {
-  boot.initrd.systemd.services = {
-    auto-installer = {
-      requires = [ "initrd-fs.target" "systemd-udevd.service" "network-online.target"];
-      after = [ "initrd-fs.target" "systemd-udevd.service" "network-online.target"];
-      requiredBy = [ "initrd.target" ];
-      before = [ "initrd.target" ];
-      unitConfig.DefaultDependencies = false;
-      serviceConfig.Type = "oneshot";
-      script = ''
+  boot.initrd.systemd = {
+    extraBin =
+      let diskConfig = diskoConfigurations.zfs-simple { disk = "\${disk}"; }; in
+      {
+        disko-create-zfs-simple = disko.lib.createScriptNoDeps diskConfig pkgs;
+        disko-mount-zfs-simple = disko.lib.mountScriptNoDeps diskConfig pkgs;
+      };
+
+    services = {
+      auto-install = {
+        requires = [ "initrd-fs.target" "systemd-udevd.service" "network-online.target"];
+        after = [ "initrd-fs.target" "systemd-udevd.service" "network-online.target"];
+        requiredBy = [ "initrd.target" ];
+        before = [ "initrd.target" ];
+        unitConfig.DefaultDependencies = false;
+        serviceConfig.Type = "oneshot";
+        script = ''
           set -euo pipefail
 
-          flake_url="$(get-kernel-param "flake_url")"
+          export flake_url="$(get-kernel-param "flake_url")"
           if [ -n "$flake_url" ]
           then
             echo "Using flake url from kernel parameter: $flake_url"
@@ -20,13 +28,22 @@ lib.mkIf config.nix-dabei.auto-install.enable {
             exit 0
           fi
 
+          export disks="$(get-kernel-param "disks")"
+          if [ -n "disks" ]
+          then
+            echo "Using disks from kernel parameter: $disks"
+          else
+            echo "No disks defined for auto-installer"
+            exit 1
+          fi
+
+
+          export disk="$disks" # TODO multi-disk support
           udevadm trigger --subsystem-match=block; udevadm settle
           echo "Formatting disk..."
-          formatScript="$(nix build --no-link --json "''${flake_url}.config.system.build.formatScript" | jq -r '.[].outputs.out')"
-          $formatScript
+          bash disko-create-zfs-simple
           echo "Mounting disk..."
-          mountScript="$(nix build --no-link --json "''${flake_url}.config.system.build.mountScript" | jq -r '.[].outputs.out')"
-          $mountScript
+          bash disko-mount-zfs-simple
 
           echo "Installing $flake_url"
           mkdir -p /mnt/{etc,tmp}
@@ -34,23 +51,22 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           nix build  --store /mnt --profile /mnt/nix/var/nix/profiles/system "''${flake_url}.config.system.build.toplevel"
           NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root /mnt -- /run/current-system/bin/switch-to-configuration boot
 
-          set -o errexit
+          echo "Unmounting & Reboot"
           umount --verbose --recursive /mnt
-          echo -e "imported zpool(s) before export"; zpool list
           zpool export -a
-          echo -e "imported zpool(s) after export"; zpool list
           reboot
       '';
-    };
+      };
 
-    #shell = {
-    #  requiredBy = [ "initrd.target" ];
-    #  unitConfig.DefaultDependencies = false;
-    #  serviceConfig.Type = "simple";
-    #  serviceConfig.Restart = "always";
-    #  script = ''
-    #    /bin/setsid /bin/sh -c 'exec /bin/sh <> /dev/console >&0 2>&1'
-    #  '';
-    #};
+      #shell = {
+      #  requiredBy = [ "initrd.target" ];
+      #  unitConfig.DefaultDependencies = false;
+      #  serviceConfig.Type = "simple";
+      #  serviceConfig.Restart = "always";
+      #  script = ''
+      #    /bin/setsid /bin/sh -c 'exec /bin/sh <> /dev/console >&0 2>&1'
+      #  '';
+      #};
+    };
   };
 }

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -2,10 +2,16 @@
 lib.mkIf config.nix-dabei.auto-install.enable {
   boot.initrd.systemd = {
     extraBin =
-      let diskConfig = diskoConfigurations.zfs-simple { disk = "\${disk}"; }; in
+      let
+        args = { inherit lib; disks = [ "\${disk1}" "\${disk2}" ]; };
+        zfs-simple = diskoConfigurations.zfs-simple args;
+        zfs-mirror = diskoConfigurations.zfs-mirror args;
+      in
       {
-        disko-create-zfs-simple = disko.lib.createScriptNoDeps diskConfig pkgs;
-        disko-mount-zfs-simple = disko.lib.mountScriptNoDeps diskConfig pkgs;
+        disko-create-zfs-simple = disko.lib.createScriptNoDeps zfs-simple pkgs;
+        disko-mount-zfs-simple = disko.lib.mountScriptNoDeps zfs-simple pkgs;
+        disko-create-zfs-mirror = disko.lib.createScriptNoDeps zfs-mirror pkgs;
+        disko-mount-zfs-mirror = disko.lib.mountScriptNoDeps zfs-mirror pkgs;
       };
 
     services = {
@@ -28,22 +34,43 @@ lib.mkIf config.nix-dabei.auto-install.enable {
             exit 0
           fi
 
-          export disks="$(get-kernel-param "disks")"
-          if [ -n "disks" ]
-          then
-            echo "Using disks from kernel parameter: $disks"
-          else
+          udevadm trigger --subsystem-match=block; udevadm settle
+
+          disks_raw="$(get-kernel-param "disks")"
+          disks_layout="''${disks_raw%%:*}"
+          disks_string="''${disks_raw##*:}"
+          declare -a disks
+          IFS="," read -a disks <<< $disks_string
+          disks_num=''${#disks[@]}
+
+          if [ $disks_num -eq 0 ]; then
             echo "No disks defined for auto-installer"
+            exit 1
+          elif [ $disks_num -ge 1 ]; then
+              for i in ''${!disks[@]}; do
+                  export "disk$((i+1))"="''${disks[i]}";
+              done
+              echo "disk1=''${disk1:-} disk2=''${disk2:-}"
+              echo "Formatting ''${disks_num} disks with layout ''${disks_layout}: ''${disks[*]}"
+
+              if [ "$disks_layout" = "zfs-single" ]; then
+                 bash disko-create-zfs-simple
+                 echo "Mounting disk..."
+                 bash disko-mount-zfs-simple
+              elif [ "$disks_layout" = "zfs-mirror" ]; then
+                 bash disko-create-zfs-mirror
+                 echo "Mounting disk..."
+                 bash disko-mount-zfs-mirror
+              else
+                 echo "Wrong layout or number of disks: ''${disks_raw}".
+                 exit 1
+              fi
+
+          else
+            echo "Unsupported disk options"
             exit 1
           fi
 
-
-          export disk="$disks" # TODO multi-disk support
-          udevadm trigger --subsystem-match=block; udevadm settle
-          echo "Formatting disk..."
-          bash disko-create-zfs-simple
-          echo "Mounting disk..."
-          bash disko-mount-zfs-simple
 
           echo "Installing $flake_url"
           mkdir -p /mnt/{etc,tmp}
@@ -53,7 +80,12 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           nix build  --store /mnt --profile /mnt/nix/var/nix/profiles/system "''${flake_url}.config.system.build.toplevel"
 
           echo "Installing grub..."
-          nixos-enter --root /mnt -- /run/current-system/sw/sbin/grub-install --removable $disk
+          # TODO read $disks from files or so, in order to be able to split the installer into phases again.
+          # ( can't depend on "global" shell vars )
+          # TODOL: uefi support: don't install grub at all, depend well-known path?
+          for disk in ''${disks[@]}; do
+              nixos-enter --root /mnt -- /run/current-system/sw/sbin/grub-install $disk
+          done
 
           echo "Switching to configuration..."
           NIXOS_INSTALL_BOOTLOADER=0 nixos-enter --root /mnt -- /run/current-system/bin/switch-to-configuration boot

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -48,8 +48,15 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           echo "Installing $flake_url"
           mkdir -p /mnt/{etc,tmp}
           touch /mnt/etc/NIXOS
+
+          echo "Installing system closure..."
           nix build  --store /mnt --profile /mnt/nix/var/nix/profiles/system "''${flake_url}.config.system.build.toplevel"
-          NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root /mnt -- /run/current-system/bin/switch-to-configuration boot
+
+          echo "Installing grub..."
+          nixos-enter --root /mnt -- /run/current-system/sw/sbin/grub-install --removable $disk
+
+          echo "Switching to configuration..."
+          NIXOS_INSTALL_BOOTLOADER=0 nixos-enter --root /mnt -- /run/current-system/bin/switch-to-configuration boot
 
           echo "Unmounting & Reboot"
           umount --verbose --recursive /mnt

--- a/modules/auto-installer.nix
+++ b/modules/auto-installer.nix
@@ -96,16 +96,6 @@ lib.mkIf config.nix-dabei.auto-install.enable {
           reboot
       '';
       };
-
-      #shell = {
-      #  requiredBy = [ "initrd.target" ];
-      #  unitConfig.DefaultDependencies = false;
-      #  serviceConfig.Type = "simple";
-      #  serviceConfig.Restart = "always";
-      #  script = ''
-      #    /bin/setsid /bin/sh -c 'exec /bin/sh <> /dev/console >&0 2>&1'
-      #  '';
-      #};
     };
   };
 }

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -31,7 +31,7 @@ with lib;
           test -f disk.img || ${pkgs.qemu_kvm}/bin/qemu-img create -f qcow2 disk.img 10G
           ssh_host_key="$(cat ${../fixtures/ssh_host_ed25519_key} | base64 -w0)"
           ssh_authorized_key="$(cat ${../fixtures/id_ed25519.pub} | base64 -w0)"
-          flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
+          flake_url="github:dep-sys/nix-dabei/?dir=demo#nixosConfigurations.web-01"
           exec ${pkgs.qemu_kvm}/bin/qemu-kvm -name nix-dabei \
             -m 2048 \
             -kernel ${kernel} -initrd ${initrd} \

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -31,7 +31,7 @@ with lib;
           test -f disk.img || ${pkgs.qemu_kvm}/bin/qemu-img create -f qcow2 disk.img 10G
           ssh_host_key="$(cat ${../fixtures/ssh_host_ed25519_key} | base64 -w0)"
           ssh_authorized_key="$(cat ${../fixtures/id_ed25519.pub} | base64 -w0)"
-          flake_url="github:dep-sys/nix-dabei?dir=demo#nixosConfigurations.web-01"
+          flake_url="github:dep-sys/nix-dabei/disko-runtime?dir=demo#nixosConfigurations.web-01"
           exec ${pkgs.qemu_kvm}/bin/qemu-kvm -name nix-dabei \
             -m 2048 \
             -kernel ${kernel} -initrd ${initrd} \

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -35,7 +35,7 @@ with lib;
           exec ${pkgs.qemu_kvm}/bin/qemu-kvm -name nix-dabei \
             -m 2048 \
             -kernel ${kernel} -initrd ${initrd} \
-            -append "console=ttyS0 init=/bin/init ${kernelParams} ssh_host_key=$ssh_host_key ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url" \
+            -append "console=ttyS0 init=/bin/init ${kernelParams} ssh_host_key=$ssh_host_key ssh_authorized_key=$ssh_authorized_key flake_url=$flake_url disks=/dev/vda" \
             -no-reboot -nographic \
             -net nic,model=virtio \
             -net user,net=10.0.2.0/24,host=10.0.2.2,dns=10.0.2.3,hostfwd=tcp::2222-:22 \

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -105,7 +105,7 @@ let cfg = config.nix-dabei; in
         ];
 
         initrd = {
-          kernelModules = [ "virtio_pci" "virtio_scsi" "ata_piix" "sd_mod" "sr_mod" "ahci" "nvme" ];
+          kernelModules = [ "virtio_pci" "virtio_scsi" "ata_piix" "sd_mod" "sr_mod" "ahci" "nvme" "e1000e" ];
           network = {
             enable = true;
           };

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -15,7 +15,7 @@ let cfg = config.nix-dabei; in
     tty-shell.enable = mkOption {
       description = "enable shell on tty1";
       type = types.bool;
-      default = true;
+      default = false;
     };
 
     stay-in-stage-1 = mkOption {
@@ -304,6 +304,7 @@ let cfg = config.nix-dabei; in
         };
         services.tty-shell = {
           requiredBy = [ "initrd.target" ];
+          conflicts = [ "shutdown.target" ];
           unitConfig.DefaultDependencies = false;
           serviceConfig.Type = "simple";
           serviceConfig.Restart = "always";

--- a/modules/core.nix
+++ b/modules/core.nix
@@ -12,6 +12,12 @@ let cfg = config.nix-dabei; in
       type = types.bool;
       default = true;
     };
+    tty-shell.enable = mkOption {
+      description = "enable shell on tty1";
+      type = types.bool;
+      default = true;
+    };
+
     stay-in-stage-1 = mkOption {
       description = "disable switching to stage-2 so sshd keeps running until reboot";
       type = types.bool;
@@ -161,27 +167,9 @@ let cfg = config.nix-dabei; in
               nixos-enter = "${pkgs.nixos-install-tools}/bin/nixos-enter";
               unshare = "${pkgs.util-linux}/bin/unshare";
 
-              ssh-keygen = "${config.programs.ssh.package}/bin/ssh-keygen";
-              setsid = "${pkgs.util-linux}/bin/setsid";
-
-              # NTP time synchronization
-              hwclock = "${pkgs.util-linux}/bin/hwclock";
-              ntpdate = "${pkgs.ntp}/bin/ntpdate";
-
-              # partitioning
-              parted = "${pkgs.parted}/bin/parted";
-              jq = "${pkgs.jq}/bin/jq";
-
-              get-kernel-param = pkgs.writeScript "get-kernel-param" ''
-                for o in $(< /proc/cmdline); do
-                    case $o in
-                        $1=*)
-                            echo "''${o#"$1="}"
-                            ;;
-                    esac
-                done
-              '';
-            };
+              # debugging
+              ip = "${pkgs.iproute2}/bin/ip";
+           };
 
             # When these are enabled, they prevent useful output from
             # going to the console
@@ -199,48 +187,54 @@ let cfg = config.nix-dabei; in
           authorizedKeys = config.users.users.root.openssh.authorizedKeys.keys;
           port = 22;
         };
-        systemd.services = {
-          setup-ssh-authorized-keys = {
-            requires = ["initrd-fs.target"];
-            after = ["initrd-fs.target"];
-            requiredBy = [ "sshd.service" ];
-            before = [ "sshd.service" ];
-            unitConfig.DefaultDependencies = false;
-            serviceConfig.Type = "oneshot";
-            script = ''
-              mkdir -p /etc/ssh/authorized_keys.d
-              param="$(get-kernel-param "ssh_authorized_key")"
-              if [ -n "$param" ]; then
-                 umask 177
-                 (echo -e "\n"; echo "$param" | base64 -d) >> /etc/ssh/authorized_keys.d/root
-                 cat /etc/ssh/authorized_keys.d/root
-                 echo "Using ssh authorized key from kernel parameter"
-              fi
-         '';
+        systemd = {
+          extraBin = {
+            ssh-keygen = "${config.programs.ssh.package}/bin/ssh-keygen";
           };
 
-          generate-ssh-host-key = {
-            requires = ["initrd-fs.target"];
-            after = ["initrd-fs.target"];
-            requiredBy = [ "sshd.service" ];
-            before = [ "sshd.service" ];
-            unitConfig.DefaultDependencies = false;
-            serviceConfig.Type = "oneshot";
-            script = ''
-              mkdir -p /etc/ssh/
+          services = {
+            setup-ssh-authorized-keys = {
+              requires = ["initrd-fs.target"];
+              after = ["initrd-fs.target"];
+              requiredBy = [ "sshd.service" ];
+              before = [ "sshd.service" ];
+              unitConfig.DefaultDependencies = false;
+              serviceConfig.Type = "oneshot";
+              script = ''
+                  mkdir -p /etc/ssh/authorized_keys.d
+                  param="$(get-kernel-param "ssh_authorized_key")"
+                  if [ -n "$param" ]; then
+                     umask 177
+                     (echo -e "\n"; echo "$param" | base64 -d) >> /etc/ssh/authorized_keys.d/root
+                     cat /etc/ssh/authorized_keys.d/root
+                     echo "Using ssh authorized key from kernel parameter"
+                  fi
+              '';
+            };
 
-              param="$(get-kernel-param "ssh_host_key")"
-              if [ -n "$param" ]; then
-                 umask 177
-                 echo "$param" | base64 -d > /etc/ssh/ssh_host_ed25519_key
-                 ssh-keygen -y -f /etc/ssh/ssh_host_ed25519_key > /etc/ssh/ssh_host_ed25519_key.pub
-                 echo "Using ssh host key from kernel parameter"
-              fi
-              if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
-                 ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -t ed25519 -N ""
-                 echo "Generated new ssh host key"
-              fi
-          '';
+            generate-ssh-host-key = {
+              requires = ["initrd-fs.target"];
+              after = ["initrd-fs.target"];
+              requiredBy = [ "sshd.service" ];
+              before = [ "sshd.service" ];
+              unitConfig.DefaultDependencies = false;
+              serviceConfig.Type = "oneshot";
+              script = ''
+                  mkdir -p /etc/ssh/
+
+                  param="$(get-kernel-param "ssh_host_key")"
+                  if [ -n "$param" ]; then
+                     umask 177
+                     echo "$param" | base64 -d > /etc/ssh/ssh_host_ed25519_key
+                     ssh-keygen -y -f /etc/ssh/ssh_host_ed25519_key > /etc/ssh/ssh_host_ed25519_key.pub
+                     echo "Using ssh host key from kernel parameter"
+                  fi
+                  if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+                     ssh-keygen -f /etc/ssh/ssh_host_ed25519_key -t ed25519 -N ""
+                     echo "Generated new ssh host key"
+                  fi
+              '';
+            };
           };
         };
       };
@@ -281,19 +275,42 @@ let cfg = config.nix-dabei; in
     # Synchronize time using NTP to prevent clock skew that could interfere
     # with date & time sensitive operations like certificate verification.
     (lib.mkIf cfg.ntpSync.enable {
-      boot.initrd.systemd.services.ntpdate-timesync = let
-       ntpServersAsString = lib.concatStringsSep " " cfg.ntpSync.servers;
-     in {
-        requires = [ "initrd-fs.target" "network-online.target"];
-        requiredBy = [ "auto-installer.service" ];
-        before = [ "auto-installer.service" ];
-        after = [ "initrd-fs.target" "network-online.target"];
-        unitConfig.DefaultDependencies = false;
-        serviceConfig.Type = "oneshot";
-        script = ''
+      boot.initrd.systemd = {
+        extraBin = {
+          hwclock = "${pkgs.util-linux}/bin/hwclock";
+          ntpdate = "${pkgs.ntp}/bin/ntpdate";
+        };
+        services.ntpdate-timesync = let
+          ntpServersAsString = lib.concatStringsSep " " cfg.ntpSync.servers;
+        in {
+          requires = [ "initrd-fs.target" "network-online.target"];
+          requiredBy = [ "auto-installer.service" ];
+          before = [ "auto-installer.service" ];
+          after = [ "initrd-fs.target" "network-online.target"];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig.Type = "oneshot";
+          script = ''
             ntpdate -b ${ntpServersAsString}
             ${lib.optionalString cfg.ntpSync.updateHwClock "hwclock --systohc"}
         '';
+        };
+      };
+    })
+
+    (lib.mkIf cfg.tty-shell.enable {
+      boot.initrd.systemd = {
+        extraBin = {
+              setsid = "${pkgs.util-linux}/bin/setsid";
+        };
+        services.tty-shell = {
+          requiredBy = [ "initrd.target" ];
+          unitConfig.DefaultDependencies = false;
+          serviceConfig.Type = "simple";
+          serviceConfig.Restart = "always";
+          script = ''
+          /bin/setsid /bin/sh -c 'exec ${pkgs.bashInteractive}/bin/bash <> /dev/console >&0 2>&1'
+        '';
+        };
       };
     })
   ];


### PR DESCRIPTION
A bunch of changes accumulated, but the most impactful ones where in the auto-installer. There's now support to automatically partition a set of disks choosen at runtime, from one of currently 2 filesystem layouts.

Those layouts must currently be known at the time your build your `nix-dabei` image, examples for zfs on 1 or 2 disks (mirrored) are included. While we would ideally fetch everything we need from the target system closure, at runtime - we run into a bootstrapping problem: We boot with a small /nix/store on `tmpfs` and would like to avoid having to store `disko`, due to the size of its dependency `nixpkgs`, before the disk is formatted.
We avoid that by using `disko` to pre-generate 2 small shell-scripts per layout, one to create and one to mount disk partitions. Dependencies of those scripts are already included in our initrd due to `boot.initrd.supportedFilesystems`, so we can execute our scripts at run-time to have everything mounted into `/mnt`.
Installation can than proceed in a chroot, where `(/mnt)/nix/store` should have enough space to evaluate and download all dependencies of our target flake, before installing the system closure to disk. 

* core, all:
  * move `extraBins` to modules that require those binaries
  * add `tty-shell` service (might not have correct systemd dependencies atm)
* demo: remove dependency on disko
* auto-install: 
  * rename from auto-installer
  * will be made more modular again.
* proof-of-concept disk partitioning
  * add `disks=zfs-single:/dev/sda` or `disks=zfs-mirror:/dev/sda,/dev/sdb` together with `flake_url="github:dep-sys/nix-dabei/?dir=demo#nixosConfigurations.web-01"` to your kernel parameters, to auto-format the given disks before auto-installing nixos.
  * boots hcloud with zfs-simple and dedicated host with 2 disks mirrored zfs
  * pretty minimal runtime-requirements, quite fast
  * still lacks:
    * safety, depends on hacked-up [disko-branch with design-changes under discussion](https://github.com/nix-community/disko/pull/72).
    * tested uefi support
    * zfs encryption
    * mirror: ensure that resulting system boots from any disk and updates both /boot partitions   