### PR TITLE
Add cross compilation targets for all linux platforms

### DIFF
--- a/modules/flake-parts/lib/default.nix
+++ b/modules/flake-parts/lib/default.nix
@@ -7,8 +7,6 @@
   flake.lib = {
     makeInstaller = modules:
       inputs.nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
-        pkgs = inputs.nixpkgs.legacyPackages."x86_64-linux";
         modules = (builtins.attrValues self.nixosModules) ++ modules;
       };
   };

--- a/modules/flake-parts/nixosModules/module.nix
+++ b/modules/flake-parts/nixosModules/module.nix
@@ -207,7 +207,6 @@ in {
             "mptspi"
             "vmxnet3"
             "vsock"
-            "vmw_balloon"
             "vmw_vmci"
             "vmwgfx"
             "vmw_vsock_vmci_transport"
@@ -240,13 +239,17 @@ in {
             "hid_cherry"
             "pcips2"
             "atkbd"
-            "i8042"
-            "rtc_cmos"
             "bridge"
             "macvlan"
             "tap"
             "tun"
-          ];
+          ]
+          # These module lead to build time errors on aarch64-linux
+          ++ (lib.optionals (config.nixpkgs.hostPlatform == "x86_64-linux") [
+            "i8042"
+            "rtc_cmos"
+            "vmw_balloon"
+          ]);
           systemd.network = {
             enable = true;
             wait-online.enable = true;

--- a/modules/flake-parts/packages/default.nix
+++ b/modules/flake-parts/packages/default.nix
@@ -9,19 +9,65 @@
     self',
     inputs',
     pkgs,
+
+    # this is our buildPlatform
     system,
     ...
-  }: {
-    packages = let
-      config = self.nixosConfigurations.default.config;
+  }: let
+
+    # For some platforms which have native artifacts cached on cache.nixos.org
+    #   we substitute some paths from the cache instead of cross compiling.
+    cachedPlatforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+
+    # For the current buildPlatform (the current system coming from perSystem),
+    #   this generates cross compiled outputs for all other systems that
+    #   that the flake produces outputs for.
+    packagesForPlatform = hostPlatform: let
+      machine = machineForPlatform hostPlatform;
+      suffix =
+        if system == hostPlatform
+        then ""
+        else "-${hostPlatform}";
     in {
-      inherit
-        (config.system.build)
-        kexec
-        kexecTarball
-        vm
-        ;
-      default = config.system.build.kexec;
+      "kexec${suffix}" = machine.config.system.build.kexec;
+      "kexecTarball${suffix}" = machine.config.system.build.kexecTarball;
+      "vm${suffix}" = machine.config.system.build.vm;
     };
+
+    # Modify the nixosConfiguration.default to target a certain hostPlatform.
+    # This sets up the machine for cross compilation.
+    machineForPlatform = hostPlatform:
+      self.nixosConfigurations.default.extendModules {
+        modules = [(
+          {
+            nixpkgs.hostPlatform = hostPlatform;
+            nixpkgs.buildPlatform = system;
+            nixpkgs.overlays = [(overlaysForPlatform hostPlatform)];
+          }
+        )];
+      };
+
+    # get some native artifacts from cache.nixos.org instead of cross building.
+    overlaysForPlatform = hostPlatform: let
+      nativePkgs = inputs.nixpkgs.legacyPackages.${hostPlatform};
+    in curr: prev:
+      if ! lib.elem hostPlatform cachedPlatforms
+      then {}
+      else {
+        nix = nativePkgs.nix;
+        nixos-isntall-tools = nativePkgs.nixos-install-tools;
+        zfs = nativePkgs.zfs;
+        rsync = nativePkgs.rsync;
+        parted = nativePkgs.parted;
+        openssh = nativePkgs.openssh;
+      };
+
+  in {
+    # merge all packages generated via the functions above.
+    packages = lib.foldl (a: b: a // b) {}
+      (map packagesForPlatform flake.config.systems);
   };
 }


### PR DESCRIPTION
based on https://github.com/dep-sys/nix-dabei/pull/41

adds cross compilation targets for all systems.
## Usage examples:
### To cross build for aarch64-linux on an x86_64-linux:
```
nix build .#packages.x86_64-linux.kexecTarball-aarch64-linux
```

### To build for aarch64 natively (or vie qemu)
```
nix build .#packages.aarch64-linux.kexecTarball
```