### PR TITLE
feat: don't use static binaries in initrd

### DIFF
--- a/modules/flake-parts/nixosModules/module.nix
+++ b/modules/flake-parts/nixosModules/module.nix
@@ -285,11 +285,12 @@ in {
             ];
 
             contents."/usr/bin/env".source = "${pkgs.coreutils}/bin/env";
+
             extraBin = {
               # nix & installer
-              nix = "${pkgs.nixStatic}/bin/nix";
-              nix-store = "${pkgs.nixStatic}/bin/nix-store";
-              nix-env = "${pkgs.nixStatic}/bin/nix-env";
+              nix = "${pkgs.nix}/bin/nix";
+              nix-store = "${pkgs.nix}/bin/nix-store";
+              nix-env = "${pkgs.nix}/bin/nix-env";
               busybox = "${pkgs.busybox-sandbox-shell}/bin/busybox";
               nixos-enter = "${pkgs.nixos-install-tools}/bin/nixos-enter";
               nixos-install = "${pkgs.nixos-install-tools}/bin/nixos-install";

--- a/modules/flake-parts/packages/default.nix
+++ b/modules/flake-parts/packages/default.nix
@@ -41,13 +41,15 @@
     # This sets up the machine for cross compilation.
     machineForPlatform = hostPlatform:
       self.nixosConfigurations.default.extendModules {
-        modules = [(
-          {
-            nixpkgs.hostPlatform = hostPlatform;
-            nixpkgs.buildPlatform = system;
-            nixpkgs.overlays = [(overlaysForPlatform hostPlatform)];
+        modules = [{
+          nixpkgs = {
+            hostPlatform = hostPlatform;
+            overlays = [(overlaysForPlatform hostPlatform)];
           }
-        )];
+          // (lib.optionalAttrs (system != hostPlatform) {
+            buildPlatform = system;
+          });
+        }];
       };
 
     # get some native artifacts from cache.nixos.org instead of cross building.
@@ -57,12 +59,13 @@
       if ! lib.elem hostPlatform cachedPlatforms
       then {}
       else {
+        jq = nativePkgs.jq;
         nix = nativePkgs.nix;
-        nixos-isntall-tools = nativePkgs.nixos-install-tools;
-        zfs = nativePkgs.zfs;
-        rsync = nativePkgs.rsync;
-        parted = nativePkgs.parted;
+        nixos-install-tools = nativePkgs.nixos-install-tools;
         openssh = nativePkgs.openssh;
+        parted = nativePkgs.parted;
+        rsync = nativePkgs.rsync;
+        zfs = nativePkgs.zfs;
       };
 
   in {


### PR DESCRIPTION
Fix some bugs and stop using static packages for initrd.
This reduces the size of the tarball.